### PR TITLE
Fix frontend hijacking /docs in development

### DIFF
--- a/{{cookiecutter.project_slug}}/frontend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/frontend/Dockerfile
@@ -25,4 +25,4 @@ FROM nginx:1.15
 COPY --from=build-stage /app/dist/ /usr/share/nginx/html
 
 COPY --from=build-stage /nginx.conf /etc/nginx/conf.d/default.conf
-COPY ./nginx-backend.conf /etc/nginx/extra-conf.d/backend-not-found.conf
+COPY ./nginx-backend-not-found.conf /etc/nginx/extra-conf.d/backend-not-found.conf

--- a/{{cookiecutter.project_slug}}/frontend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/frontend/Dockerfile
@@ -25,3 +25,4 @@ FROM nginx:1.15
 COPY --from=build-stage /app/dist/ /usr/share/nginx/html
 
 COPY --from=build-stage /nginx.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx-backend.conf /etc/nginx/extra-conf.d/backend-not-found.conf

--- a/{{cookiecutter.project_slug}}/frontend/nginx-backend-not-found.conf
+++ b/{{cookiecutter.project_slug}}/frontend/nginx-backend-not-found.conf
@@ -1,0 +1,9 @@
+location /api {
+    return 404;
+}
+location /docs {
+    return 404;
+}
+location /redoc {
+    return 404;
+}


### PR DESCRIPTION
:bug: Fix frontend hijacking /docs in development. Using latest https://github.com/tiangolo/node-frontend with custom Nginx configs in frontend.