### PR TITLE
Updated backend.dockerfile to work with new base image python:3.6

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -6,7 +6,20 @@ RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add -
     echo "deb http://packages.couchbase.com/ubuntu ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list && \
     apt-get update && apt-get install -y libcouchbase-dev libcouchbase2-bin build-essential
 
-RUN pip install celery~=4.3 passlib[bcrypt] tenacity requests couchbase emails "fastapi>=0.16.0" uvicorn gunicorn pyjwt python-multipart email_validator jinja2
+RUN pip install \
+    celery~=4.3 \
+    passlib[bcrypt] \
+    tenacity \
+    requests \
+    couchbase \
+    emails \
+    "fastapi>=0.16.0" \
+    uvicorn \
+    gunicorn \
+    pyjwt \
+    python-multipart \
+    email_validator \
+    jinja2
 
 # For development, Jupyter remote kernel, Hydrogen
 # Using inside the container:

--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -1,9 +1,10 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.6
 
 # Dependencies for Couchbase
-RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add -
-RUN echo "deb http://packages.couchbase.com/ubuntu stretch stretch/main" > /etc/apt/sources.list.d/couchbase.list
-RUN apt-get update && apt-get install -y libcouchbase-dev libcouchbase2-bin build-essential
+RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add - && \
+    OS_CODENAME=`cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d=` && \
+    echo "deb http://packages.couchbase.com/ubuntu ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list && \
+    apt-get update && apt-get install -y libcouchbase-dev libcouchbase2-bin build-essential
 
 RUN pip install celery~=4.3 passlib[bcrypt] tenacity requests couchbase emails "fastapi>=0.16.0" uvicorn gunicorn pyjwt python-multipart email_validator jinja2
 

--- a/{{cookiecutter.project_slug}}/backend/tests.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/tests.dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.6
 
-RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add -
-RUN echo "deb http://packages.couchbase.com/ubuntu stretch stretch/main" > /etc/apt/sources.list.d/couchbase.list
-RUN apt-get update && apt-get install -y libcouchbase-dev build-essential
+RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add - && \
+    OS_CODENAME=`cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d=` && \
+    echo "deb http://packages.couchbase.com/ubuntu ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list && \
+    apt-get update && apt-get install -y libcouchbase-dev build-essential
 
 RUN pip install requests pytest tenacity passlib[bcrypt] couchbase "fastapi>=0.16.0"
 


### PR DESCRIPTION
With a `python:3.6` base image relying on Debian Buster and not Debian Stretch, the installation of couchbase failed. We referenced stretch whereas buster is expected with new `python:3.6` base image

The error can be seen [here](https://travis-ci.org/Gjacquenot/full-stack-fastapi-couchbase/builds/606215286)