### PR TITLE
Simplify Traefik labels for services

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.deploy.labels.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.deploy.labels.yml
@@ -8,11 +8,8 @@ services:
         - traefik.port=8091
         - traefik.tags=${TRAEFIK_PUBLIC_TAG}
         - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
   sync-gateway:
     deploy:
       labels:
@@ -21,11 +18,8 @@ services:
         - traefik.port=4984
         - traefik.tags=${TRAEFIK_PUBLIC_TAG}
         - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
   proxy:
     deploy:
       labels:
@@ -38,18 +32,15 @@ services:
         - traefik.port=80
         - traefik.tags=${TRAEFIK_PUBLIC_TAG}
         - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}
-        # Traefik service that listens to HTTP
-        - traefik.servicehttp.frontend.entryPoints=http
-        - traefik.servicehttp.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.servicehttps.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
         # Uncomment the config line below to detect and redirect www to non-www (or the contrary)
         # The lines above for traefik.frontend.rule are needed too
-        # - "traefik.servicehttps.frontend.redirect.regex=^https?://(www.)?(${DOMAIN})/(.*)"
+        # - "traefik.frontend.redirect.regex=^https?://(www.)?(${DOMAIN})/(.*)"
         # To redirect from non-www to www un-comment the line below
-        # - "traefik.servicehttps.frontend.redirect.replacement=https://www.${DOMAIN}/$$3"
+        # - "traefik.frontend.redirect.replacement=https://www.${DOMAIN}/$$3"
         # To redirect from www to non-www un-comment the line below
-        # - "traefik.servicehttps.frontend.redirect.replacement=https://${DOMAIN}/$$3"
+        # - "traefik.frontend.redirect.replacement=https://${DOMAIN}/$$3"
   flower:
     deploy:
       labels:
@@ -58,11 +49,8 @@ services:
         - traefik.port=5555
         - traefik.tags=${TRAEFIK_PUBLIC_TAG}
         - traefik.docker.network=${TRAEFIK_PUBLIC_NETWORK}
-        # Traefik service that listens to HTTP
-        - traefik.redirectorservice.frontend.entryPoints=http
-        - traefik.redirectorservice.frontend.redirect.entryPoint=https
-        # Traefik service that listens to HTTPS
-        - traefik.webservice.frontend.entryPoints=https
+        - traefik.frontend.entryPoints=http,https
+        - traefik.frontend.redirect.entryPoint=https
   backend:
     deploy:
       labels:


### PR DESCRIPTION
:recycle: Simplify Traefik labels for services, taking the ideas from https://github.com/tiangolo/dockerswarm.rocks/pull/22