### PR TITLE
Fix Windows shell scripts line endings after generation

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+path: Path
+for path in Path(".").glob("**/*.sh"):
+    data = path.read_bytes()
+    lf_data = data.replace(b"\r\n", b"\n")
+    path.write_bytes(lf_data)


### PR DESCRIPTION
:bug: Fix Windows line endings for shell scripts after generation.

This uses Cookiecutter hooks and pathlib to replace all CR LF characters with LF in `*.sh` files.

https://cookiecutter.readthedocs.io/en/latest/advanced/hooks.html