### PR TITLE
Cannot setup environment

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -1,10 +1,11 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.6
 
 # Dependencies for Couchbase
-RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add - && \
+RUN wget -O - https://packages.couchbase.com/clients/c/repos/deb/couchbase.key | apt-key add - && \
     OS_CODENAME=`cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d=` && \
-    echo "deb http://packages.couchbase.com/ubuntu ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list && \
-    apt-get update && apt-get install -y libcouchbase-dev libcouchbase2-bin build-essential
+    VERSION_ID=`cat /etc/os-release | grep VERSION_ID | cut -f2 -d= | cut -f2 -d'"'` && \
+    echo "deb https://packages.couchbase.com/clients/c/repos/deb/debian${VERSION_ID} ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list && \
+    apt-get update && apt-get install -y libcouchbase3 libcouchbase-dev libcouchbase3-tools libcouchbase-dbg libcouchbase3-libev build-essential
 
 RUN pip install \
     celery~=4.3 \

--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -8,13 +8,13 @@ RUN wget -O - https://packages.couchbase.com/clients/c/repos/deb/couchbase.key |
     apt-get update && apt-get install -y libcouchbase3 libcouchbase-dev libcouchbase3-tools libcouchbase-dbg libcouchbase3-libev build-essential
 
 RUN pip install \
-    celery~=4.3 \
+    celery \
     passlib[bcrypt] \
     tenacity \
     requests \
     couchbase \
     emails \
-    "fastapi>=0.16.0" \
+    fastapi \
     uvicorn \
     gunicorn \
     pyjwt \

--- a/{{cookiecutter.project_slug}}/backend/tests.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/tests.dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.6
 
-RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add - && \
+RUN wget -O - https://packages.couchbase.com/clients/c/repos/deb/couchbase.key | apt-key add - && \
     OS_CODENAME=`cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d=` && \
-    echo "deb http://packages.couchbase.com/ubuntu ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list && \
+    VERSION_ID=`cat /etc/os-release | grep VERSION_ID | cut -f2 -d= | cut -f2 -d'"'` && \
+    echo "deb https://packages.couchbase.com/clients/c/repos/deb/debian${VERSION_ID} ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list && \
     apt-get update && apt-get install -y libcouchbase-dev build-essential
 
 RUN pip install requests pytest tenacity passlib[bcrypt] couchbase "fastapi>=0.16.0"


### PR DESCRIPTION
Hi  [Sebastián Ramírez](https://github.com/tiangolo)

The installation `couchbase` is changed, so i fix it according to:
https://docs.couchbase.com/c-sdk/current/project-docs/sdk-release-notes.html

Here is showed problem step by step.
```[pypros@pyprospc full-stack-fastapi-couchbase]$ git branch
* master
[pypros@pyprospc full-stack-fastapi-couchbase]$ python3 -m venv .venv
[pypros@pyprospc full-stack-fastapi-couchbase]$ source .venv/
bash: source: .venv/: is a directory
[pypros@pyprospc full-stack-fastapi-couchbase]$ source .venv/bin/activate
(.venv) [pypros@pyprospc full-stack-fastapi-couchbase]$ pip install cookiecutter
Collecting cookiecutter
  Using cached cookiecutter-1.7.3-py2.py3-none-any.whl (34 kB)
Collecting python-slugify>=4.0.0
  Using cached python_slugify-6.1.1-py2.py3-none-any.whl (9.1 kB)
Collecting poyo>=0.5.0
  Using cached poyo-0.5.0-py2.py3-none-any.whl (10 kB)
Collecting click>=7.0
  Using cached click-8.1.2-py3-none-any.whl (96 kB)
Collecting binaryornot>=0.4.4
  Using cached binaryornot-0.4.4-py2.py3-none-any.whl (9.0 kB)
Collecting six>=1.10
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting Jinja2<4.0.0,>=2.7
  Using cached Jinja2-3.1.1-py3-none-any.whl (132 kB)
Collecting jinja2-time>=0.2.0
  Using cached jinja2_time-0.2.0-py2.py3-none-any.whl (6.4 kB)
Collecting requests>=2.23.0
  Using cached requests-2.27.1-py2.py3-none-any.whl (63 kB)
Collecting chardet>=3.0.2
  Using cached chardet-4.0.0-py2.py3-none-any.whl (178 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
Collecting arrow
  Using cached arrow-1.2.2-py3-none-any.whl (64 kB)
Collecting text-unidecode>=1.3
  Using cached text_unidecode-1.3-py2.py3-none-any.whl (78 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
Collecting charset-normalizer~=2.0.0
  Using cached charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.9-py2.py3-none-any.whl (138 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Collecting python-dateutil>=2.7.0
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Installing collected packages: text-unidecode, certifi, urllib3, six, python-slugify, poyo, MarkupSafe, idna, click, charset-normalizer, chardet, requests, python-dateutil, Jinja2, binaryornot, arrow, jinja2-time, cookiecutter
Successfully installed Jinja2-3.1.1 MarkupSafe-2.1.1 arrow-1.2.2 binaryornot-0.4.4 certifi-2021.10.8 chardet-4.0.0 charset-normalizer-2.0.12 click-8.1.2 cookiecutter-1.7.3 idna-3.3 jinja2-time-0.2.0 poyo-0.5.0 python-dateutil-2.8.2 python-slugify-6.1.1 requests-2.27.1 six-1.16.0 text-unidecode-1.3 urllib3-1.26.9
(.venv) [pypros@pyprospc full-stack-fastapi-couchbase]$ python -m cookiecutter .
project_name [Base Project]: example_setup_project
project_slug [example_setup_project]: 
domain_main [example_setup_project.com]: 
domain_staging [stag.example_setup_project.com]: 
docker_swarm_stack_name_main [example_setup_project-com]: 
docker_swarm_stack_name_staging [stag-example_setup_project-com]: 
secret_key [changethis]: 
first_superuser [admin@example_setup_project.com]: 
first_superuser_password [changethis]: 
backend_cors_origins [http://localhost, http://localhost:4200, http://localhost:3000, http://localhost:8080, https://localhost, https://localhost:4200, https://localhost:3000, https://localhost:8080, http://dev.example_setup_project.com, https://stag.example_setup_project.com, https://example_setup_project.com, http://local.dockertoolbox.tiangolo.com, http://localhost.tiangolo.com]: 
smtp_port [587]: 
smtp_host []: 
smtp_user []: 
smtp_password []: 
smtp_emails_from_email [info@example_setup_project.com]: 
couchbase_user [admin]: 
couchbase_password [changethis]: 
couchbase_sync_gateway_cors [http://localhost:4984, http://localhost:4985, http://localhost, http://localhost:4200, http://localhost:3000, http://localhost:8080, http://dev.example_setup_project.com, https://stag.example_setup_project.com, https://db.stag.example_setup_project.com, https://example_setup_project.com, https://db.example_setup_project.com, http://local.dockertoolbox.tiangolo.com, http://local.dockertoolbox.tiangolo.com:4984, http://localhost.tiangolo.com, http://localhost.tiangolo.com:4984]: 
couchbase_sync_gateway_user [sync]: 
couchbase_sync_gateway_password [changethis]: 
traefik_constraint_tag [example_setup_project.com]: 
traefik_constraint_tag_staging [stag.example_setup_project.com]: 
traefik_public_network [traefik-public]: 
traefik_public_constraint_tag [traefik-public]: 
flower_auth [admin:changethis]: 
sentry_dsn []: 
docker_image_prefix []: 
docker_image_backend [backend]: 
docker_image_celeryworker [celeryworker]: 
docker_image_frontend [frontend]: 
docker_image_sync_gateway [sync-gateway]: 
(.venv) [pypros@pyprospc full-stack-fastapi-couchbase]$ ls
cookiecutter.json              dev-fsfcb-config.yml  Dockerfile             LICENSE         scripts
{{cookiecutter.project_slug}}  dev-fsfcb.sh          example_setup_project  README.md       testing-config.yml
dev-fsfcb-back.sh              diff.diff             hooks                  screenshot.png  test.sh
(.venv) [pypros@pyprospc full-stack-fastapi-couchbase]$ cd example_setup_project/
(.venv) [pypros@pyprospc example_setup_project]$ docker-compose up -d
[+] Building 19.4s (42/58)                                                                                                                  
 => [example_setup_project_sync-gateway internal] load build definition from Dockerfile                                                0.0s
 => => transferring dockerfile: 180B                                                                                                   0.0s
 => [example_setup_project_frontend internal] load build definition from Dockerfile                                                    0.0s
 => => transferring dockerfile: 701B                                                                                                   0.0s
 => [example_setup_project_backend-tests internal] load build definition from tests.dockerfile                                         0.1s
 => => transferring dockerfile: 1.15kB                                                                                                 0.0s
 => [example_setup_project_celeryworker internal] load build definition from celeryworker.dockerfile                                   0.1s
 => => transferring dockerfile: 953B                                                                                                   0.0s
 => [example_setup_project_backend internal] load build definition from backend.dockerfile                                             0.3s
 => => transferring dockerfile: 1.05kB                                                                                                 0.0s
 => [example_setup_project_sync-gateway internal] load .dockerignore                                                                   0.1s
 => => transferring context: 2B                                                                                                        0.0s
 => [example_setup_project_frontend internal] load .dockerignore                                                                       0.2s
 => => transferring context: 53B                                                                                                       0.0s
 => [example_setup_project_backend-tests internal] load .dockerignore                                                                  0.2s
 => => transferring context: 2B                                                                                                        0.0s
 => [example_setup_project_celeryworker internal] load .dockerignore                                                                   0.3s
 => => transferring context: 2B                                                                                                        0.0s
 => [example_setup_project_backend internal] load .dockerignore                                                                        0.3s
 => => transferring context: 2B                                                                                                        0.0s
 => [example_setup_project_sync-gateway internal] load metadata for docker.io/couchbase/sync-gateway:2.1.0-community                   1.3s
 => [example_setup_project_frontend internal] load metadata for docker.io/library/nginx:1.15                                           1.2s
 => [example_setup_project_frontend internal] load metadata for docker.io/tiangolo/node-frontend:10                                    1.2s
 => [example_setup_project_celeryworker internal] load metadata for docker.io/library/python:3.6                                       0.0s
 => CACHED [example_setup_project_celeryworker 1/7] FROM docker.io/library/python:3.6                                                  0.0s
 => [example_setup_project_backend-tests internal] load build context                                                                  0.1s
 => => transferring context: 97.35kB                                                                                                   0.0s
 => ERROR [example_setup_project_backend-tests 2/7] RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add -  18.6s
 => [example_setup_project_celeryworker internal] load build context                                                                   0.1s
 => => transferring context: 97.35kB                                                                                                   0.0s
 => CACHED [example_setup_project_celeryworker  2/10] RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add   0.0s 
 => CACHED [example_setup_project_celeryworker  3/10] RUN echo "deb http://packages.couchbase.com/ubuntu stretch stretch/main" > /etc  0.0s 
 => CACHED [example_setup_project_celeryworker  4/10] RUN apt-get update && apt-get install -y libcouchbase-dev build-essential        0.0s 
 => CANCELED [example_setup_project_celeryworker  5/10] RUN pip install raven celery~=4.3 passlib[bcrypt] tenacity requests "fastapi  18.8s 
 => [example_setup_project_backend internal] load metadata for docker.io/tiangolo/uvicorn-gunicorn-fastapi:python3.6                   1.2s 
 => [example_setup_project_frontend internal] load build context                                                                       0.0s 
 => => transferring context: 162.17kB                                                                                                  0.0s
 => [example_setup_project_frontend build-stage 1/7] FROM docker.io/tiangolo/node-frontend:10@sha256:10046f2c98460dc97c490e98ee828d2f  0.0s
 => CACHED [example_setup_project_frontend stage-1 1/4] FROM docker.io/library/nginx:1.15@sha256:23b4dcdf0d34d4a129755fc6f52e1c6e23bb  0.0s
 => [example_setup_project_sync-gateway 1/5] FROM docker.io/couchbase/sync-gateway:2.1.0-community@sha256:174404d22de4ca406ff1d23aade  0.0s
 => [example_setup_project_sync-gateway internal] load build context                                                                   0.1s
 => => transferring context: 5.91kB                                                                                                    0.0s
 => CACHED [example_setup_project_frontend build-stage 2/7] WORKDIR /app                                                               0.0s
 => CACHED [example_setup_project_frontend build-stage 3/7] COPY package*.json /app/                                                   0.0s
 => CACHED [example_setup_project_frontend build-stage 4/7] RUN npm install                                                            0.0s
 => [example_setup_project_frontend build-stage 5/7] COPY ./ /app/                                                                     0.2s
 => CACHED [example_setup_project_backend 1/5] FROM docker.io/tiangolo/uvicorn-gunicorn-fastapi:python3.6@sha256:cc4a0c8ba18a68887d9f  0.0s
 => [example_setup_project_backend internal] load build context                                                                        0.1s
 => => transferring context: 97.35kB                                                                                                   0.0s
 => CACHED [example_setup_project_sync-gateway 2/5] COPY /entrypoint.sh /                                                              0.0s
 => CACHED [example_setup_project_sync-gateway 3/5] RUN chmod +x ./entrypoint.sh                                                       0.0s
 => CACHED [example_setup_project_sync-gateway 4/5] COPY /create_config.py /                                                           0.0s
 => CACHED [example_setup_project_sync-gateway 5/5] COPY /sync/ /sync/                                                                 0.0s
 => [example_setup_project_sync-gateway] exporting to image                                                                            0.2s
 => => exporting layers                                                                                                                0.0s
 => => writing image sha256:4944996c9f87c794b6d088362a3353b263ad6afc36402cfa1ba5928f08601c82                                           0.0s
 => => naming to docker.io/library/example_setup_project_sync-gateway                                                                  0.0s
 => CANCELED [example_setup_project_backend 2/5] RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add - &&  17.4s
 => [example_setup_project_frontend build-stage 6/7] RUN npm run test:unit                                                             4.9s
 => CANCELED [example_setup_project_frontend build-stage 7/7] RUN npm run build                                                       12.6s
------
 > [example_setup_project_backend-tests 2/7] RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add - &&     OS_CODENAME=`cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d=` &&     echo "deb http://packages.couchbase.com/ubuntu ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list &&     apt-get update && apt-get install -y libcouchbase-dev build-essential:
#0 0.397 --2022-04-25 20:34:20--  http://packages.couchbase.com/ubuntu/couchbase.key
#0 0.397 Resolving packages.couchbase.com (packages.couchbase.com)... Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
#0 5.486 52.84.194.118, 52.84.194.57, 52.84.194.41, ...
#0 5.486 Connecting to packages.couchbase.com (packages.couchbase.com)|52.84.194.118|:80... connected.
#0 5.499 HTTP request sent, awaiting response... 200 OK
#0 5.514 Length: 4815 (4.7K) [application/pgp-keys]
#0 5.514 Saving to: ‘STDOUT’
#0 5.514 
#0 5.514      0K ....                                                  100%  693M=0s
#0 5.514 
#0 5.514 2022-04-25 20:34:25 (693 MB/s) - written to stdout [4815/4815]
#0 5.514 
#0 6.039 OK
#0 16.17 Get:1 http://security.debian.org/debian-security bullseye-security InRelease [44.1 kB]
#0 16.17 Get:2 http://deb.debian.org/debian bullseye InRelease [116 kB]
#0 16.26 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [39.4 kB]
#0 16.31 Get:4 http://security.debian.org/debian-security bullseye-security/main amd64 Packages [126 kB]
#0 16.32 Err:5 http://packages.couchbase.com/ubuntu bullseye InRelease
#0 16.32   403  Forbidden [IP: 52.84.194.118 80]
#0 16.38 Get:6 http://deb.debian.org/debian bullseye/main amd64 Packages [8182 kB]
#0 16.69 Get:7 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [2596 B]
#0 17.98 Reading package lists...
#0 18.51 E: Failed to fetch http://packages.couchbase.com/ubuntu/dists/bullseye/InRelease  403  Forbidden [IP: 52.84.194.118 80]
#0 18.51 E: The repository 'http://packages.couchbase.com/ubuntu bullseye InRelease' is not signed.
------
failed to solve: executor failed running [/bin/sh -c wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add - &&     OS_CODENAME=`cat /etc/os-release | grep VERSION_CODENAME | cut -f2 -d=` &&     echo "deb http://packages.couchbase.com/ubuntu ${OS_CODENAME} ${OS_CODENAME}/main" > /etc/apt/sources.list.d/couchbase.list &&     apt-get update && apt-get install -y libcouchbase-dev build-essential]: exit code: 100
(.venv) [pypros@pyprospc example_setup_project]$ docker-compose stop
(.venv) [pypros@pyprospc example_setup_project]$ git branch
* master
```